### PR TITLE
Enhance path filtering with filter_paths input and path_level support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@ GitHub action used to get the changed paths between two commits or refs.
 
 **Organization:** LerianStudio
 
-## Inputs
-
-| Name           | Description                                                                 |
-|----------------|-----------------------------------------------------------------------------|
-| `filter_string` | (Optional) Filters changed paths to only include those containing this string (e.g., `infra`, `frontend`). |
+| Name            | Required | Description                                                                 |
+|-----------------|----------|-----------------------------------------------------------------------------|
+| `filter_string` | No       | Optional. Filters changed paths to only include those containing this string. |
+| `path_level`    | No       | Optional. Limits the path to the first N segments (e.g., 2 → `components/transactions`). |
 
 ## Outputs
 
@@ -41,6 +40,7 @@ This action does not export any environment variables.
           uses: LerianStudio/github-actions-changed-paths@main
           with:
             filter_string: components
+            path_level: 2
 
     # Example using the matrix output
     run-per-path:

--- a/README.md
+++ b/README.md
@@ -4,10 +4,13 @@ GitHub action used to get the changed paths between two commits or refs.
 
 **Organization:** LerianStudio
 
+## Inputs
+
 | Name            | Required | Description                                                                 |
 |-----------------|----------|-----------------------------------------------------------------------------|
-| `filter_paths` | No       | Optional. A list of path prefixes to filter results. |
-| `path_level`    | No       | Optional. Limits the path to the first N segments. |
+| `filter_paths`  | No       | Optional. A list of path prefixes to filter results. One per line.          |
+| `path_level`    | No       | Optional. Limits the output path to the first N segments.                   |
+| `get_app_name`  | No       | Optional. If true, outputs a matrix with `name` and `working_dir` fields for each app. Assumes second path segment is the app name. |
 
 ## Outputs
 
@@ -42,6 +45,7 @@ This action does not export any environment variables.
             filter_paths: |-
               components/onboarding
               components/transaction
+            get_app_name: true
             path_level: 2
 
     # Example using the matrix output

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ GitHub action used to get the changed paths between two commits or refs.
 
 | Name            | Required | Description                                                                 |
 |-----------------|----------|-----------------------------------------------------------------------------|
-| `filter_paths` | No       | Optional. JSON array of path prefixes to filter results (e.g., ["components/mdz", "components/transaction"]). |
-| `path_level`    | No       | Optional. Limits the path to the first N segments (e.g., 2 → `components/transactions`). |
+| `filter_paths` | No       | Optional. A list of path prefixes to filter results. |
+| `path_level`    | No       | Optional. Limits the path to the first N segments. |
 
 ## Outputs
 
@@ -39,7 +39,9 @@ This action does not export any environment variables.
           id: changed-paths
           uses: LerianStudio/github-actions-changed-paths@main
           with:
-            filter_paths: ["components/mdz", "components/transaction"]
+            filter_paths: |-
+              components/onboarding
+              components/transaction
             path_level: 2
 
     # Example using the matrix output

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ GitHub action used to get the changed paths between two commits or refs.
 
 | Name            | Required | Description                                                                 |
 |-----------------|----------|-----------------------------------------------------------------------------|
-| `filter_string` | No       | Optional. Filters changed paths to only include those containing this string. |
+| `filter_paths` | No       | Optional. JSON array of path prefixes to filter results (e.g., ["components/mdz", "components/transaction"]). |
 | `path_level`    | No       | Optional. Limits the path to the first N segments (e.g., 2 → `components/transactions`). |
 
 ## Outputs
@@ -39,7 +39,7 @@ This action does not export any environment variables.
           id: changed-paths
           uses: LerianStudio/github-actions-changed-paths@main
           with:
-            filter_string: components
+            filter_paths: ["components/mdz", "components/transaction"]
             path_level: 2
 
     # Example using the matrix output

--- a/action.yaml
+++ b/action.yaml
@@ -51,17 +51,29 @@ runs:
           DIRS=$(echo "$DIRS" | cut -d'/' -f-"$PATH_LEVEL")
         fi
 
+        # Filter paths if filter_paths is a non-empty JSON array
         if [[ "$FILTER_PATHS" != "" && "$FILTER_PATHS" != "[]" ]]; then
           echo "Filtering directories using list: $FILTER_PATHS"
+
+          # Try to parse JSON — if it fails, attempt to quote items to recover
+          if ! echo "$FILTER_PATHS" | jq empty >/dev/null 2>&1; then
+            echo "⚠️ Provided filter_paths is not valid JSON, attempting to recover..."
+            FILTER_PATHS=$(echo "$FILTER_PATHS" | sed 's/\([^[,[:space:]]\+\)/"\1"/g' | sed 's/^/[/;s/$/]/')
+          fi
+
           FILTERED=""
           while read -r DIR; do
-            jq -r '.[]' <<< "$FILTER_PATHS" | while read -r FILTER; do
+            MATCHED=false
+            while read -r FILTER; do
               if [[ "$DIR" == "$FILTER"* ]]; then
                 FILTERED+="$DIR"$'\n'
+                MATCHED=true
                 break
               fi
-            done
+            done < <(jq -r '.[]' <<< "$FILTER_PATHS")
+            $MATCHED && continue
           done <<< "$DIRS"
+
           DIRS="$FILTERED"
         fi
 

--- a/action.yaml
+++ b/action.yaml
@@ -1,9 +1,9 @@
 name: 'Get changed paths'
 
 inputs:
-  filter_string:
+  filter_paths:
     required: false
-    description: 'Optional. Filters changed paths to only include those containing this string'
+    description: 'Optional. JSON array of path prefixes to filter results (e.g., ["components/mdz", "components/transaction"])'
   path_level:
     required: false
     description: 'Optional. Limits the path to the first N segments (e.g., 2 -> "components/transactions")'
@@ -33,7 +33,7 @@ runs:
       shell: bash
       run: |
         FILES="${{ steps.changed.outputs.files }}"
-        FILTER_STRING="${{ inputs.filter_string || '' }}"
+        FILTER_PATHS="${{ inputs.filter_paths || '' }}"
         PATH_LEVEL="${{ inputs.path_level || '' }}"
 
         if [[ -z "$FILES" ]]; then
@@ -42,25 +42,32 @@ runs:
           exit 0
         fi
 
-        # Extract unique directories
+        # Get directory for each file
         DIRS=$(echo "$FILES" | xargs -n1 dirname)
 
         # Trim to first N path segments if specified
         if [[ -n "$PATH_LEVEL" ]]; then
-          echo "🔢 Trimming paths to first $PATH_LEVEL segments"
+          echo "Trimming paths to first $PATH_LEVEL segments"
           DIRS=$(echo "$DIRS" | cut -d'/' -f-"$PATH_LEVEL")
         fi
 
-        # Apply filter if provided
-        if [[ -n "$FILTER_STRING" ]]; then
-          echo "🔍 Filtering directories with string: $FILTER_STRING"
-          DIRS=$(echo "$DIRS" | grep "$FILTER_STRING" || true)
+        # Filter paths if filter_paths is a non-empty JSON array
+        if [[ "$FILTER_PATHS" != "" && "$FILTER_PATHS" != "[]" ]]; then
+          echo "Filtering directories using list: $FILTER_PATHS"
+          FILTERED=""
+          while read -r DIR; do
+            for FILTER in $(echo "$FILTER_PATHS" | jq -r '.[]'); do
+              if [[ "$DIR" == "$FILTER"* ]]; then
+                FILTERED+="$DIR"$'\n'
+                break
+              fi
+            done
+          done <<< "$DIRS"
+          DIRS="$FILTERED"
         fi
 
-        # Convert to JSON array
+        # Deduplicate and convert to compact JSON array
         DIRS_JSON=$(echo "$DIRS" | sort -u | jq -Rc . | jq -sc .)
 
-        echo "✅ Changed directories matrix: $DIRS_JSON"
-
-        # Save to GitHub output
+        echo "Changed directories matrix: $DIRS_JSON"
         printf "matrix=%s\n" "$DIRS_JSON" >> "$GITHUB_OUTPUT"

--- a/action.yaml
+++ b/action.yaml
@@ -7,6 +7,9 @@ inputs:
   path_level:
     required: false
     description: 'Optional. Limits the path to the first N segments (e.g., 2 -> "components/transactions")'
+  get_app_name:
+    required: false
+    description: 'If true, outputs a matrix of objects with app name and working directory. Otherwise, outputs a list of changed directories.'
 
 outputs:
   matrix:
@@ -35,6 +38,7 @@ runs:
         FILES="${{ steps.changed.outputs.files }}"
         FILTER_PATHS="${{ inputs.filter_paths || '' }}"
         PATH_LEVEL="${{ inputs.path_level || '' }}"
+        GET_APP_NAME="${{ inputs.get_app_name || 'false' }}"
 
         if [[ -z "$FILES" ]]; then
           echo "No files changed."
@@ -69,11 +73,38 @@ runs:
             done
           done <<< "$DIRS"
 
+          # If nothing matched, exit
+          if [[ -z "$FILTERED" ]]; then
+            echo "No matching directories found after filtering."
+            printf "matrix=[]\n" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           DIRS="$FILTERED"
         fi
 
-        # Deduplicate and convert to compact JSON array, filtering out empty lines
-        DIRS_JSON=$(echo "$DIRS" | grep -v '^$' | sort -u | jq -Rc . | jq -sc .)
+        # Deduplicate and remove empty lines
+        DIRS=$(echo "$DIRS" | grep -v '^$' | sort -u)
 
-        echo "Changed directories matrix: $DIRS_JSON"
-        printf "matrix=%s\n" "$DIRS_JSON" >> "$GITHUB_OUTPUT"
+        if [[ "$GET_APP_NAME" == "true" ]]; then
+          echo "Generating object matrix with app names"
+          MATRIX="["
+          FIRST=true
+          while read -r DIR; do
+            APP_NAME="midaz-$(echo "$DIR" | cut -d'/' -f2)"
+            ENTRY="{\"name\":\"$APP_NAME\",\"working_dir\":\"$DIR\"}"
+            if $FIRST; then
+              MATRIX+="$ENTRY"
+              FIRST=false
+            else
+              MATRIX+=",$ENTRY"
+            fi
+          done <<< "$DIRS"
+          MATRIX+="]"
+        else
+          # Default: return just an array of paths
+          MATRIX=$(echo "$DIRS" | jq -Rc . | jq -sc .)
+        fi
+
+        echo "Changed directories matrix: $MATRIX"
+        printf "matrix=%s\n" "$MATRIX" >> "$GITHUB_OUTPUT"

--- a/action.yaml
+++ b/action.yaml
@@ -51,27 +51,22 @@ runs:
           DIRS=$(echo "$DIRS" | cut -d'/' -f-"$PATH_LEVEL")
         fi
 
-        # Filter paths if filter_paths is a non-empty JSON array
-        if [[ "$FILTER_PATHS" != "" && "$FILTER_PATHS" != "[]" ]]; then
-          echo "Filtering directories using list: $FILTER_PATHS"
+        # Filter paths if filter_paths is provided
+        if [[ -n "$FILTER_PATHS" ]]; then
+          echo "Filtering directories using list:"
+          echo "$FILTER_PATHS"
 
-          # Try to parse JSON — if it fails, attempt to quote items to recover
-          if ! echo "$FILTER_PATHS" | jq empty >/dev/null 2>&1; then
-            echo "⚠️ Provided filter_paths is not valid JSON, attempting to recover..."
-            FILTER_PATHS=$(echo "$FILTER_PATHS" | sed 's/\([^[,[:space:]]\+\)/"\1"/g' | sed 's/^/[/;s/$/]/')
-          fi
+          # Convert multi-line input into array
+          mapfile -t FILTER_ARRAY <<< "$FILTER_PATHS"
 
           FILTERED=""
           while read -r DIR; do
-            MATCHED=false
-            while read -r FILTER; do
+            for FILTER in "${FILTER_ARRAY[@]}"; do
               if [[ "$DIR" == "$FILTER"* ]]; then
                 FILTERED+="$DIR"$'\n'
-                MATCHED=true
                 break
               fi
-            done < <(jq -r '.[]' <<< "$FILTER_PATHS")
-            $MATCHED && continue
+            done
           done <<< "$DIRS"
 
           DIRS="$FILTERED"

--- a/action.yaml
+++ b/action.yaml
@@ -4,6 +4,9 @@ inputs:
   filter_string:
     required: false
     description: 'Optional. Filters changed paths to only include those containing this string'
+  path_level:
+    required: false
+    description: 'Optional. Limits the path to the first N segments (e.g., 2 -> "components/transactions")'
 
 outputs:
   matrix:
@@ -31,6 +34,7 @@ runs:
       run: |
         FILES="${{ steps.changed.outputs.files }}"
         FILTER_STRING="${{ inputs.filter_string || '' }}"
+        PATH_LEVEL="${{ inputs.path_level || '' }}"
 
         if [[ -z "$FILES" ]]; then
           echo "No files changed."
@@ -38,8 +42,14 @@ runs:
           exit 0
         fi
 
-        # Extract unique directories (one per line)
-        DIRS=$(echo "$FILES" | xargs -n1 dirname | sort -u)
+        # Extract unique directories
+        DIRS=$(echo "$FILES" | xargs -n1 dirname)
+
+        # Trim to first N path segments if specified
+        if [[ -n "$PATH_LEVEL" ]]; then
+          echo "🔢 Trimming paths to first $PATH_LEVEL segments"
+          DIRS=$(echo "$DIRS" | cut -d'/' -f-"$PATH_LEVEL")
+        fi
 
         # Apply filter if provided
         if [[ -n "$FILTER_STRING" ]]; then
@@ -47,8 +57,8 @@ runs:
           DIRS=$(echo "$DIRS" | grep "$FILTER_STRING" || true)
         fi
 
-        # Convert to compact JSON array
-        DIRS_JSON=$(echo "$DIRS" | jq -Rc . | jq -sc .)
+        # Convert to JSON array
+        DIRS_JSON=$(echo "$DIRS" | sort -u | jq -Rc . | jq -sc .)
 
         echo "✅ Changed directories matrix: $DIRS_JSON"
 

--- a/action.yaml
+++ b/action.yaml
@@ -72,8 +72,8 @@ runs:
           DIRS="$FILTERED"
         fi
 
-        # Deduplicate and convert to compact JSON array
-        DIRS_JSON=$(echo "$DIRS" | sort -u | jq -Rc . | jq -sc .)
+        # Deduplicate and convert to compact JSON array, filtering out empty lines
+        DIRS_JSON=$(echo "$DIRS" | grep -v '^$' | sort -u | jq -Rc . | jq -sc .)
 
         echo "Changed directories matrix: $DIRS_JSON"
         printf "matrix=%s\n" "$DIRS_JSON" >> "$GITHUB_OUTPUT"

--- a/action.yaml
+++ b/action.yaml
@@ -51,12 +51,11 @@ runs:
           DIRS=$(echo "$DIRS" | cut -d'/' -f-"$PATH_LEVEL")
         fi
 
-        # Filter paths if filter_paths is a non-empty JSON array
         if [[ "$FILTER_PATHS" != "" && "$FILTER_PATHS" != "[]" ]]; then
           echo "Filtering directories using list: $FILTER_PATHS"
           FILTERED=""
           while read -r DIR; do
-            for FILTER in $(echo "$FILTER_PATHS" | jq -r '.[]'); do
+            jq -r '.[]' <<< "$FILTER_PATHS" | while read -r FILTER; do
               if [[ "$DIR" == "$FILTER"* ]]; then
                 FILTERED+="$DIR"$'\n'
                 break


### PR DESCRIPTION
**Title:** Enhance directory extraction with `get_app_name` support

**Description:**

This PR includes the following changes:

- **Added `get_app_name` input**: When set to `true`, the matrix output will include objects with `name` and `working_dir` fields.
  - `name` is generated using the second path segment prefixed with `midaz-`.
  - `working_dir` is the filtered directory path.
- Path filter option. 
- Improved `filter_paths` logic: if no directories match the filters, the workflow exits early.
- Updated `README.md` with `get_app_name` input and adjusted descriptions for clarity.