### PR TITLE
Add support for optional app name prefix in matrix output

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This action does not export any environment variables.
               components/transaction
             get_app_name: true
             path_level: 2
+            app_name_prefix: midaz
 
     # Example using the matrix output
     run-per-path:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ GitHub action used to get the changed paths between two commits or refs.
 | `filter_paths`  | No       | Optional. A list of path prefixes to filter results. One per line.          |
 | `path_level`    | No       | Optional. Limits the output path to the first N segments.                   |
 | `get_app_name`  | No       | Optional. If true, outputs a matrix with `name` and `working_dir` fields for each app. Assumes second path segment is the app name. |
+| `app_name_prefix` | No | Optional. Adds a prefix to the generated app names when `get_app_name` is enabled. Ignored if `get_app_name` is false. |
 
 ## Outputs
 

--- a/action.yaml
+++ b/action.yaml
@@ -10,6 +10,9 @@ inputs:
   get_app_name:
     required: false
     description: 'If true, outputs a matrix of objects with app name and working directory. Otherwise, outputs a list of changed directories.'
+  app_name_prefix:
+    required: false
+    description: 'Optional. If set and get_app_name is true, this prefix will be added to each app name.'
 
 outputs:
   matrix:
@@ -39,6 +42,7 @@ runs:
         FILTER_PATHS="${{ inputs.filter_paths || '' }}"
         PATH_LEVEL="${{ inputs.path_level || '' }}"
         GET_APP_NAME="${{ inputs.get_app_name || 'false' }}"
+        APP_NAME_PREFIX="${{ inputs.app_name_prefix || '' }}"
 
         if [[ -z "$FILES" ]]; then
           echo "No files changed."
@@ -91,7 +95,11 @@ runs:
           MATRIX="["
           FIRST=true
           while read -r DIR; do
-            APP_NAME="$(echo "$DIR" | cut -d'/' -f2)"
+            if [[ -n "$APP_NAME_PREFIX" ]]; then
+              APP_NAME="${APP_NAME_PREFIX}-$(echo "$DIR" | cut -d'/' -f2)"
+            else
+              APP_NAME="$(echo "$DIR" | cut -d'/' -f2)"
+            fi
             ENTRY="{\"name\":\"$APP_NAME\",\"working_dir\":\"$DIR\"}"
             if $FIRST; then
               MATRIX+="$ENTRY"


### PR DESCRIPTION
**Title**: Add support for optional app name prefix in matrix output

**Description**:  
This update introduces a new input parameter `app_name_prefix` to the shared workflow. When used in combination with `get_app_name: true`, it prepends the given prefix to each generated app name in the matrix output. If the prefix is not provided, the app name will default to the second-level path segment as before.

Also includes an update to the README to document the new input.