### PR TITLE
fix(action): use pull_request.base.sha for PR event diffs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,10 @@ runs:
       id: changed
       shell: bash
       run: |
-        if [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]] || [[ -z "${{ github.event.before }}" ]]; then
+        if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "pull_request_target" ]]; then
+          # For PRs, diff between the base branch and current HEAD
+          FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD)
+        elif [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]] || [[ -z "${{ github.event.before }}" ]]; then
           # For tags or when before is not available, compare with the previous commit
           PREV_COMMIT=$(git rev-parse HEAD^)
           if [[ $? -eq 0 ]]; then


### PR DESCRIPTION
 ## Summary

  - Fix `fatal: bad object` error on `pull_request` synchronize events (e.g., force-pushes)
  - Use `github.event.pull_request.base.sha` instead of `github.event.before` for PR diffs

  ## Problem

  `github.event.before` on `pull_request` synchronize events contains the **previous PR head SHA**, which may no longer be reachable after
   a force-push — even with `fetch-depth: 0`. This causes:

  fatal: bad object

  The first PR run (`opened` event) works because `github.event.before` is empty, triggering the `HEAD^` fallback. All subsequent runs
  (`synchronize`) fail.

  ## Fix

  Added a check for `pull_request` / `pull_request_target` events that uses `github.event.pull_request.base.sha` — the target branch
  commit, which is always available in the checkout and is the correct diff base for PRs.

  ## Impact

  All repositories using this action via shared-workflows (`pr-security-scan`, `build`, etc.) will be fixed automatically since they
  reference `@main`.